### PR TITLE
Cleanup output of devices command when adb server not started yet

### DIFF
--- a/CoolADB/Class1.cs
+++ b/CoolADB/Class1.cs
@@ -120,11 +120,12 @@ namespace CoolADB
         {
             List<string> devices = new List<string>();
             SendCommand("\"" + adbPath + "\" devices");
-            int lineIndex = 0;
+            int lineIndex = -1;
             foreach (string line in output.Split('\n'))
             {
-                if (lineIndex > 0) devices.Add(line.Split().First());
                 lineIndex++;
+                if (lineIndex == 0 || String.IsNullOrEmpty(line) || line[0] == '*') continue;
+                devices.Add(line.Split().First());
             }
             return devices;
         }


### PR DESCRIPTION
Found that when adb server is not started, and someone is trying to get devices, next message is appearing in console:
```
* daemon not running. starting it now at tcp:5037 *
* daemon started successfully *
[device name]
...
```
Also response contains some empty line and line with '\r' symbol (also empty string). So the output of function is:
```
[0] *
[1] *
[2] [device name]
...
[n-1] [empty string]
[n] [empty string]
```
Using negative index is something dumb, but it is necessary due to placing incremental operation at the start of loop.