### PR TITLE
Fix for hanging Process when adb push and pull - Disposable Process for memory 

### DIFF
--- a/CoolADB/Class1.cs
+++ b/CoolADB/Class1.cs
@@ -22,6 +22,14 @@ namespace CoolADB
             }
         }
 
+        // ----------------------------------------- Adb command timeout - usable in push and pull to avoid hanging while executing
+        private int adbTimeout;
+        public int AdbTimeout
+        {
+            get { return adbTimeout > 0 ? adbTimeout : 5000; }
+            set { adbTimeout = value; }
+        }
+
         // ----------------------------------------- Create our emulated shell here and assign events
 
         // Create a background thread an assign work event to our emulated shell method
@@ -40,21 +48,31 @@ namespace CoolADB
         // Create an emulated shell for executing commands
         private void CMD_Send(object sender, DoWorkEventArgs e)
         {
-            Process process = new Process();
-            Shell = process;
-            ProcessStartInfo startInfo = new ProcessStartInfo();
-            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            startInfo.CreateNoWindow = true;
-            startInfo.UseShellExecute = false;
-            startInfo.RedirectStandardOutput = true;
-            startInfo.FileName = "cmd.exe";
-            startInfo.Arguments = "/C \"" + Command + "\"";
-            process.StartInfo = startInfo;
-            process.Start();
-            if (Command.StartsWith("\"" + adbPath + "\" logcat")) Complete = true;
-            process.WaitForExit();
-            Output = process.StandardOutput.ReadToEnd();
-            Complete = true;
+            ProcessStartInfo startInfo = new ProcessStartInfo()
+            {
+                WindowStyle = ProcessWindowStyle.Hidden,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                FileName = "cmd.exe",
+                Arguments = "/C \"" + Command + "\""
+            };
+
+            using (Process process = Process.Start(startInfo))
+            {
+                if (Command.StartsWith("\"" + adbPath + "\" logcat"))
+                {
+                    Complete = true;
+                    process.WaitForExit();
+                    return;
+                }
+
+                if (!process.WaitForExit(AdbTimeout))
+                    process.Kill();
+
+                Output = process.StandardOutput.ReadToEnd();
+                Complete = true;
+            };
         }
 
         // Send a command to emulated shell


### PR DESCRIPTION
Fix for hanging Process when adb push - References #4 
Disposable Process for memory leak avoidage - Process objects in CMD_Send was never disposed